### PR TITLE
Fixed JpName being erased and BossByte being moved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ atlassian-ide-plugin.xml
 
 bin/
 *.rect
+.settings/org.eclipse.jdt.core.prefs
+.classpath
+.project

--- a/src/ca/noxid/lab/gameinfo/GameInfo.java
+++ b/src/ca/noxid/lab/gameinfo/GameInfo.java
@@ -1027,6 +1027,7 @@ public class GameInfo {
 				newMap.setNPC2(StrTools.CString(buf32, encoding));
 				newMap.setBoss(dBuf.get());
 				dBuf.get(buf32);
+				newMap.setJpName(buf32);
 				dBuf.get(buf32);
 				newMap.setMapname(StrTools.CString(buf32, encoding));
 				newMap.markUnchanged();

--- a/src/ca/noxid/lab/mapdata/MapInfo.java
+++ b/src/ca/noxid/lab/mapdata/MapInfo.java
@@ -11,7 +11,6 @@ import ca.noxid.lab.tile.LineSeg;
 import ca.noxid.lab.tile.MapPoly;
 import ca.noxid.lab.tile.ShiftDialog;
 import com.carrotlord.string.StrTools;
-import com.sun.istack.internal.NotNull;
 
 import javax.swing.undo.AbstractUndoableEdit;
 import javax.swing.undo.UndoManager;
@@ -649,7 +648,7 @@ public class MapInfo implements Changeable {
 		}
 
 		@Override
-		public int compareTo(@NotNull PxeEntry other) {
+		public int compareTo(PxeEntry other) {
 			Integer fp = filePos;
 			return fp.compareTo(other.filePos);
 		}

--- a/src/ca/noxid/lab/mapdata/Mapdata.java
+++ b/src/ca/noxid/lab/mapdata/Mapdata.java
@@ -201,7 +201,7 @@ public class Mapdata implements Changeable {
 			retVal.position(0xA4);
 			retVal.put((byte) bossNum);
 			retVal.position(0xA5);
-			retVal.put(jpName, 0, 0x1f);
+			retVal.put(jpName, 0, (jpName.length < 0x20) ? jpName.length : 0x1F);
 			retVal.position(0xC5);
 			try {
 				byte[] letters = mapName.getBytes(charEncoding);

--- a/src/ca/noxid/lab/mapdata/Mapdata.java
+++ b/src/ca/noxid/lab/mapdata/Mapdata.java
@@ -106,6 +106,13 @@ public class Mapdata implements Changeable {
 	}
 	public String getMapname() {return mapName;}
 	
+	private byte[] jpName;
+	public void setJpName(byte[] b){
+		markChanged();
+		jpName = b.clone();
+	}
+	public byte[] getJpName() {return jpName.clone();}
+	
 	private int scrollType;
 	public void setScroll(int n) {
 		if (n != scrollType) {
@@ -151,6 +158,7 @@ public class Mapdata implements Changeable {
 		bossNum = 0;
 		mapName = Messages.getString("Mapdata.0");		 //$NON-NLS-1$
 		mapNum = num;
+		jpName = new byte[0x20];
 	}
 
 	public ByteBuffer toBuf(MOD_TYPE format, String charEncoding) throws UnsupportedEncodingException {
@@ -190,8 +198,11 @@ public class Mapdata implements Changeable {
 			retVal.put(npcSet1.getBytes(charEncoding), 0, npcSet1.length() < 0x20 ? npcSet1.length() : 0x1F);
 			retVal.position(0x84);
 			retVal.put(npcSet2.getBytes(charEncoding), 0, npcSet2.length() < 0x20 ? npcSet2.length() : 0x1F);
-			retVal.position(0xC4);
+			retVal.position(0xA4);
 			retVal.put((byte) bossNum);
+			retVal.position(0xA5);
+			retVal.put(jpName, 0, 0x1f);
+			retVal.position(0xC5);
 			try {
 				byte[] letters = mapName.getBytes(charEncoding);
 				retVal.put(letters, 0, letters.length < 0x23 ? letters.length : 0x22);

--- a/src/ca/noxid/lab/script/TscPane.java
+++ b/src/ca/noxid/lab/script/TscPane.java
@@ -400,7 +400,7 @@ public class TscPane extends JTextPane implements ActionListener, Changeable {
 				JLabel label = new JLabel(face);
 				label.setBackground(Color.black);
 				jp.add(label);
-			} catch (RasterFormatException ignored) {
+			} catch (Exception ignored) {
 			}
 			break;
 		case 'i': //item #


### PR DESCRIPTION
Issues fixed:
-git will ignore my eclipse files
-game will no longer fail to open maps if you don't have face.bmp
-game will SAVE BOSS BYTE IN PROPER SPOT for CS+ maps
-game will no longer throw away the japanese names of maps in existing
maps in the table (you can't edit these with BL still though)