### PR TITLE
Fix NPE when exporting CS maps as CS+ stage.tbl

### DIFF
--- a/src/ca/noxid/lab/mapdata/Mapdata.java
+++ b/src/ca/noxid/lab/mapdata/Mapdata.java
@@ -295,6 +295,8 @@ public class Mapdata implements Changeable {
 			retVal.position(0xA4);
 			retVal.put((byte) bossNum);
 			retVal.position(0xA5);
+			if (jpName == null)
+				jpName = new byte[0];
 			retVal.put(jpName, 0, (jpName.length < 0x20) ? jpName.length : 0x1F);
 			retVal.position(0xC5);
 			try {


### PR DESCRIPTION
Reported by rain#3321 on the CS Modding Community Discord server.
```
Exception in thread "AWT-EventQueue-0" java.lang.NullPointerException
    at ca.noxid.lab.mapdata.Mapdata.toBuf(Mapdata.java:298)
    at ca.noxid.lab.gameinfo.GameInfo.exportMapdata(GameInfo.java:932)
    at ca.noxid.lab.EditorApp$17.actionPerformed(EditorApp.java:967)
```